### PR TITLE
Chore/rename to dotenv_validator

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,7 +18,7 @@ assignees: ''
 
 **Version, Branch, or Commit:**
 
-Inform what version, branch, commit of Dotenv Checker you are using.
+Inform what branch/commit/version of "dotenv_validator" you are using.
 
 **Expected behavior:**
 
@@ -50,4 +50,4 @@ _Delete any information that is not relevant._
 
 Include relevant log snippets or files here.
 
-**I will abide by the [code of conduct] (https://github.com/fastruby/dotenv_checker/blob/master/CODE_OF_CONDUCT.md)**
+**I will abide by the [code of conduct](https://github.com/fastruby/dotenv_validator/blob/main/CODE_OF_CONDUCT.md)**

--- a/README.md
+++ b/README.md
@@ -1,36 +1,37 @@
-# Dotenv Checker
+# Dotenv Validator
 
-This gem check if required env variables are present and its format using the .env and .env.sample files from Dotenv.
+This gem validates `.env` variables. You can configure validation rules by adding the
+appropriate comments to the `.env.sample` file.
 
 # Installation
 
 Add the gem to your gemfile:
 
 ```
-gem "dotenv_checker", github: "fastruby/dotenv_checker", branch: :main
+gem "dotenv_validator", github: "fastruby/dotenv_validator", branch: :main
 ```
 
-Call `DotenvChecker.check!` in an initializer:
+Call `DotenvValidator.check!` in an initializer:
 
 ```
-echo "DotenvChecker.check!" > "config/initializers/1-dotenv-checker.rb"
+echo "DotenvValidator.check!" > "config/initializers/1_dotenv_validator.rb"
 ```
 
 > Note the `1-` in the name so it's executed before any other initializer, since initializers are run in alphabetical order.
 
-> You can use `DotenvChecker.check` without the `!` to show warnings instead of raising an exception.
+> You can use `DotenvValidator.check` without the `!` to show warnings instead of raising an exception.
 
 ## Updating
 
-Since right know it's only available from GitHub, run:
+At the moment it is only available on Github, so you would need to run:
 
 ```
-bundle update --source dotenv_checker
+bundle update --source dotenv_validator
 ```
 
 # Configuring env variable
 
-In your `.env.sample` file, you can add comments to tell DotenvChecker how to validate the variable:
+In your `.env.sample` file, you can add comments to tell DotenvValidator how to validate the variable:
 
 ```
 MY_REQUIRED_VAR=value #required
@@ -59,7 +60,7 @@ In the above example, `\d{3}_\w{3}` is converted to a regexp and the value is ch
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at [https://github.com/fastruby/dotenv_checker](https://github.com/fastruby/dotenv_checker). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at [https://github.com/fastruby/dotenv_validator](https://github.com/fastruby/dotenv_validator). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 When Submitting a Pull Request:
 

--- a/dotenv_validator.gemspec
+++ b/dotenv_validator.gemspec
@@ -1,14 +1,14 @@
 Gem::Specification.new do |s|
-  s.name = "dotenv_checker"
+  s.name = "dotenv_validator"
   s.version = "1.0.0"
   s.authors = ["Ariel Juodziukynas <arieljuod@gmail.com>"]
   s.email = "arieljuod@gmail.com"
   s.licenses = ["MIT"]
-  s.summary = "Checks required env variables and its format using .evn and .env.sample files from Dotenv"
-  s.description = "Checks required env variables and its format using .evn and .env.sample files from Dotenv"
-  s.homepage = "https://github.com/fastruby/dotenv_checker"
+  s.summary = "Checks required env variables and its format using .env and .env.sample files from Dotenv"
+  s.description = "Checks required env variables and its format using .env and .env.sample files from Dotenv"
+  s.homepage = "https://github.com/fastruby/dotenv_validator"
   s.files = [
-    "lib/dotenv_checker.rb"
+    "lib/dotenv_validator.rb"
   ]
   s.require_paths = ["lib"]
 

--- a/lib/dotenv_validator.rb
+++ b/lib/dotenv_validator.rb
@@ -1,6 +1,6 @@
 require "fast_blank"
 
-module DotenvChecker
+module DotenvValidator
   def self.analyze_variables
     return [], [] unless File.exist?(sample_file)
 

--- a/spec/dot_env_validator_spec.rb
+++ b/spec/dot_env_validator_spec.rb
@@ -1,17 +1,18 @@
 require "spec_helper"
 
-RSpec.describe DotenvChecker do
+RSpec.describe DotenvValidator do
   let(:sample_lines) { StringIO.new("") }
 
   before do
     allow(File).to receive(:exist?).and_return(true)
-    allow(DotenvChecker).to receive(:open_sample_file).and_return(sample_lines)
+    allow(DotenvValidator).to receive(:open_sample_file).and_return(sample_lines)
+    allow(STDOUT).to receive(:puts) # this supresses puts
   end
 
   describe ".check" do
     context "when there are no variables" do
       it "returns true" do
-        expect(DotenvChecker.check).to be_truthy
+        expect(DotenvValidator.check).to be_truthy
       end
     end
 
@@ -23,20 +24,20 @@ RSpec.describe DotenvChecker do
       context "and ENV has said variable" do
         it "returns true" do
           ClimateControl.modify admin_password: "solarwinds123" do
-            expect(DotenvChecker.check).to be_truthy
+            expect(DotenvValidator.check).to be_truthy
           end
         end
       end
 
       context "and ENV does not have said variable" do
         it "returns false" do
-          expect(DotenvChecker.check).to be_falsey
+          expect(DotenvValidator.check).to be_falsey
         end
 
         it "displays a warning message in STDOUT" do
           msg = "WARNING - Missing environment variables: admin_password\n"
           expect do
-            DotenvChecker.check
+            DotenvValidator.check
           end.to output(msg).to_stdout
         end
       end
@@ -47,7 +48,7 @@ RSpec.describe DotenvChecker do
         let(:sample_lines) { StringIO.new("DISCOUNT=20") }
 
         it "returns true" do
-          expect(DotenvChecker.check).to be_truthy
+          expect(DotenvValidator.check).to be_truthy
         end
       end
 
@@ -57,7 +58,7 @@ RSpec.describe DotenvChecker do
         context "and ENV variable is an integer" do
           it "returns true" do
             ClimateControl.modify DISCOUNT: "42" do
-              expect(DotenvChecker.check).to be_truthy
+              expect(DotenvValidator.check).to be_truthy
             end
           end
         end
@@ -65,7 +66,7 @@ RSpec.describe DotenvChecker do
         context "and ENV variable is not an integer" do
           it "returns false" do
             ClimateControl.modify DISCOUNT: "twenty" do
-              expect(DotenvChecker.check).to be_falsey
+              expect(DotenvValidator.check).to be_falsey
             end
           end
 
@@ -74,7 +75,7 @@ RSpec.describe DotenvChecker do
 
             ClimateControl.modify DISCOUNT: "twenty" do
               expect do
-                DotenvChecker.check
+                DotenvValidator.check
               end.to output(msg).to_stdout
             end
           end
@@ -87,7 +88,7 @@ RSpec.describe DotenvChecker do
         context "and ENV variable is an url" do
           it "returns true" do
             ClimateControl.modify DISCOUNT_URL: "https://fastruby.io" do
-              expect(DotenvChecker.check).to be_truthy
+              expect(DotenvValidator.check).to be_truthy
             end
           end
         end
@@ -95,7 +96,7 @@ RSpec.describe DotenvChecker do
         context "and ENV variable is not an url" do
           it "returns false" do
             ClimateControl.modify DISCOUNT_URL: "foo/bar" do
-              expect(DotenvChecker.check).to be_falsey
+              expect(DotenvValidator.check).to be_falsey
             end
           end
 
@@ -104,7 +105,7 @@ RSpec.describe DotenvChecker do
 
             ClimateControl.modify DISCOUNT_URL: "foo/bar" do
               expect do
-                DotenvChecker.check
+                DotenvValidator.check
               end.to output(msg).to_stdout
             end
           end
@@ -117,7 +118,7 @@ RSpec.describe DotenvChecker do
         context "and ENV variable matches regexp" do
           it "returns true" do
             ClimateControl.modify KEY_ID: "567_FOO" do
-              expect(DotenvChecker.check).to be_truthy
+              expect(DotenvValidator.check).to be_truthy
             end
           end
         end
@@ -125,7 +126,7 @@ RSpec.describe DotenvChecker do
         context "and ENV variable is not an url" do
           it "returns false" do
             ClimateControl.modify KEY_ID: "567_12" do
-              expect(DotenvChecker.check).to be_falsey
+              expect(DotenvValidator.check).to be_falsey
             end
           end
 
@@ -134,7 +135,7 @@ RSpec.describe DotenvChecker do
 
             ClimateControl.modify KEY_ID: "567_88" do
               expect do
-                DotenvChecker.check
+                DotenvValidator.check
               end.to output(msg).to_stdout
             end
           end
@@ -147,8 +148,8 @@ RSpec.describe DotenvChecker do
     context "when there are no variables" do
       it "does not raise an error" do
         expect do
-          DotenvChecker.check!
-        end.not_to raise_error(RuntimeError)
+          DotenvValidator.check!
+        end.not_to raise_error
       end
     end
 
@@ -161,8 +162,8 @@ RSpec.describe DotenvChecker do
         it "does not raise an error" do
           ClimateControl.modify admin_password: "solarwinds123" do
             expect do
-              DotenvChecker.check!
-            end.not_to raise_error(RuntimeError)
+              DotenvValidator.check!
+            end.not_to raise_error
           end
         end
       end
@@ -171,7 +172,7 @@ RSpec.describe DotenvChecker do
         it "raises a runtime error with a message" do
           msg = "Missing environment variables: admin_password"
           expect do
-            DotenvChecker.check!
+            DotenvValidator.check!
           end.to raise_error(RuntimeError, msg)
         end
       end
@@ -183,8 +184,8 @@ RSpec.describe DotenvChecker do
 
         it "does not raise an error" do
           expect do
-            DotenvChecker.check!
-          end.not_to raise_error(RuntimeError)
+            DotenvValidator.check!
+          end.not_to raise_error
         end
       end
 
@@ -195,8 +196,8 @@ RSpec.describe DotenvChecker do
           it "does not raise a runtime error" do
             ClimateControl.modify DISCOUNT: "42" do
               expect do
-                DotenvChecker.check!
-              end.not_to raise_error(RuntimeError)
+                DotenvValidator.check!
+              end.not_to raise_error
             end
           end
         end
@@ -207,7 +208,7 @@ RSpec.describe DotenvChecker do
 
             ClimateControl.modify DISCOUNT: "twenty" do
               expect do
-                DotenvChecker.check!
+                DotenvValidator.check!
               end.to raise_error(RuntimeError, msg)
             end
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ if ENV["COVERAGE"] == "true"
   puts "Using SimpleCov v#{SimpleCov::VERSION}"
 end
 
-require "dotenv_checker"
+require "dotenv_validator"
 require "climate_control"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Description:

This gem is renamed and so all references to dotenv_checker (and similar names) have to be renamed to match dotenv-validator.

After the name change I ran the tests and noticed many warnings which made it harder to understand the test output.
I eliminated warnings being printed during a test run by stubbing STDOUT.

Other warning were generated by RSpec itself - I adjusted the specs to
take care of these.

We have renamed the gem to follow this convention: https://guides.rubygems.org/name-your-gem/

Once this PR is merged, then we can also update the issues and features templates.
https://github.com/fastruby/dotenv_validator/pull/11/ and
https://github.com/fastruby/dot_env_validator/pull/12

I will abide by the code of conduct.
