### PR TITLE
Fix string format validation

### DIFF
--- a/lib/dotenv_validator.rb
+++ b/lib/dotenv_validator.rb
@@ -29,7 +29,7 @@ module DotenvValidator
         case Regexp.last_match(1)
         when 'int', 'integer' then integer?(value)
         when 'float' then float?(value)
-        when 'str', 'string' then false
+        when 'str', 'string' then true
         when 'email' then email?(value)
         when 'url' then url?(value)
         else

--- a/spec/dot_env_validator_spec.rb
+++ b/spec/dot_env_validator_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe DotenvValidator do
         end
       end
 
+      context 'and there is a string format parameter in the comment' do
+        let(:sample_lines) { StringIO.new('NAME=20 # format=string') }
+
+        context 'and ENV variable is a string' do
+          it 'returns true' do
+            ClimateControl.modify NAME: 'something' do
+              expect(DotenvValidator.check).to be_truthy
+            end
+          end
+        end
+      end
+
       context 'and there is an integer format parameter in the comment' do
         let(:sample_lines) { StringIO.new('DISCOUNT=20 # format=integer') }
 

--- a/spec/dot_env_validator_spec.rb
+++ b/spec/dot_env_validator_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe DotenvValidator do
       end
 
       context 'and there is a string format parameter in the comment' do
+        # anything counts as a string, since env variables are all strings by default
         let(:sample_lines) { StringIO.new('NAME=20 # format=string') }
 
         context 'and ENV variable is a string' do


### PR DESCRIPTION
Closes #28 

**Description:**

There was an error with the code that considered all `format=string` as invalid format. Added a test too.

**How to test/QA:**

You can add the gem using this branch instead of `:main` in a gemfile.

I will abide by the code of conduct.
