### PR TITLE
Explicitly require "pathname" from the stdlib

### DIFF
--- a/lib/dotenv_validator.rb
+++ b/lib/dotenv_validator.rb
@@ -1,4 +1,5 @@
 require 'fast_blank'
+require 'pathname'
 
 # Knows how to check the environment variables and compares it to .env.sample
 # and the comments in every line of your .env.sample file.


### PR DESCRIPTION
Every spec was failing for me due to `Pathname` not being defined. IDK why it didn't fail for everyone else, but it needs to be explicitly required.

```sh
# Tests pass with this change
$ rake spec
/Users/josh/.rubies/ruby-3.0.2/bin/ruby -I/Users/josh/.gem/ruby/3.0.2/gems/rspec-support-3.10.2/lib:/Users/josh/.gem/ruby/3.0.2/gems/rspec-core-3.10.1/lib /Users/josh/.gem/ruby/3.0.2/gems/rspec-core-3.10.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

Randomized with seed 61580
.....................

Finished in 0.01305 seconds (files took 0.06699 seconds to load)
21 examples, 0 failures

Randomized with seed 61580


# Stash the change
$ git stash
Saved working directory and index state WIP on explicitly-require-pathname: dbfe346 Merge pull request #29 from fastruby/fixes/wrong-string-validation


# Now tests fail b/c it can't find `Pathname`
$ rspec --fail-fast

Randomized with seed 49529
F

Failures:

  1) DotenvValidator.check when there is a variable that is required and ENV does not have said variable returns false
     Failure/Error: root_or_pwd = Pathname.new(ENV["RAILS_ROOT"] || Dir.pwd)

     NameError:
       uninitialized constant DotenvValidator::Pathname
     # ./lib/dotenv_validator.rb:126:in `root'
     # ./lib/dotenv_validator.rb:117:in `sample_file'
     # ./lib/dotenv_validator.rb:11:in `analyze_variables'
     # ./lib/dotenv_validator.rb:51:in `check'
     # ./spec/dot_env_validator_spec.rb:34:in `block (5 levels) in <top (required)>'

Finished in 0.00941 seconds (files took 0.09596 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/dot_env_validator_spec.rb:33 # DotenvValidator.check when there is a variable that is required and ENV does not have said variable returns false

Randomized with seed 49529
```

I will abide by the code of conduct.
