### PR TITLE
Drop dependency on dotenv

### DIFF
--- a/dotenv_validator.gemspec
+++ b/dotenv_validator.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   ]
   s.require_paths = ['lib']
 
-  s.add_dependency 'dotenv', '>= 2.7', '< 3.0'
   s.add_dependency 'fast_blank', '~> 1.0.0'
 
   s.add_development_dependency 'byebug', '>= 11.1', '< 12.0'


### PR DESCRIPTION
Hi there,

There is no real usage of the `dotenv` gem in this library. So I don't think that dependency is needed any more.

Fixes #23.

I will abide by the code of conduct.
