### PR TITLE
email and URL validation: use standard regexes

### DIFF
--- a/lib/dotenv_validator.rb
+++ b/lib/dotenv_validator.rb
@@ -99,7 +99,7 @@ module DotenvValidator
   # @param [String] A string
   # @return [Boolean] True if it is an email value. False otherwise.
   def self.email?(string)
-    string.match?(/[\w@]+@[\w@]+\.[\w@]+/)
+    string.match?(URI::MailTo::EMAIL_REGEXP)
   end
 
   # It checks the value to check if it is a URL or not.
@@ -107,7 +107,7 @@ module DotenvValidator
   # @param [String] A string
   # @return [Boolean] True if it is an URL value. False otherwise.
   def self.url?(string)
-    string.match?(%r{https?://.+})
+    string.match?(/\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/)
   end
 
   def self.open_sample_file


### PR DESCRIPTION
Closes #35.

Use regexes provided by ruby standard library for validation of emails and HTTP URLs.

Changes:
- Use `URI::MailTo::EMAIL_REGEXP` for email validation
- Use `/\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/` for HTTP URL validation