### PR TITLE
add boolean format options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # main [(unreleased)](https://github.com/fastruby/dotenv_validator/compare/v1.0.0...main)
 
 * [BUGFIX] Fix the way that we calculate the path to the .env.sample file (by [@etagwerker][])
+* [Feature] Add boolean format
 
 # v1.0.0 / 2021-07-29 [(commits)](https://github.com/fastruby/dotenv_validator/tree/v1.0.0)
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ THIS_IS_A_REQUIRED_EMAIL=123 #required,format=email
 - `str` or `string` (accepts anything)
 - `email` (checks value against `/[\w@]+@[\w@]+\.[\w@]+/`)
 - `url` (checks value against `/https?:\/\/.+/`)
+- `bool` or `boolean` (checks value against `true` or `false`, case sensitive)
 - any other value acts as a regexp!
 
 ### Regexp format

--- a/lib/dotenv_validator.rb
+++ b/lib/dotenv_validator.rb
@@ -33,6 +33,7 @@ module DotenvValidator
         when 'str', 'string' then true
         when 'email' then email?(value)
         when 'url' then url?(value)
+        when 'bool', 'boolean' then boolean?(value)
         else
           value.match?(Regexp.new(Regexp.last_match(1)))
         end
@@ -108,6 +109,14 @@ module DotenvValidator
   # @return [Boolean] True if it is an URL value. False otherwise.
   def self.url?(string)
     string.match?(%r{https?://.+})
+  end
+
+  # It checks the value to check if it is a boolean or not.
+  #
+  # @param [String] A string
+  # @return [Boolean] True if it is a boolean value. False otherwise.
+  def self.boolean?(string)
+    string.match?(/(true|false)/)
   end
 
   def self.open_sample_file


### PR DESCRIPTION
Closes #34  

Description:
Adds:
* `when` case for `'bool'` and `'boolean'`
* `boolean?` method to check variable
* relevant tests for boolean ENV variables

Additional thought:
Since ENV variables are strings, this just checks that it equals either `'true'` or `'false'`. Francois pointed out that it should maybe also cover both of those capitalized as well.

I will abide by the code of conduct.
