### PR TITLE
disable new cops by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,4 @@
 inherit_from: .rubocop_todo.yml
+
+AllCops:
+  NewCops: disable


### PR DESCRIPTION
Closes #37.

Description:
Added the following to `.rubocop.yml`:
```yaml
AllCops:
  NewCops: disable
```

I went with disabling all new cops because it seemed like it would cause less surprising behavior than having commits potentially fail every time a new cop is added.



I will abide by the code of conduct.
