### PR TITLE
Fixing lint ci job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   lint:
+    runs-on: ${{ matrix.os }}-latest
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Closes #49 

Description:
- Lint job was missing `runs-on` property

I will abide by the [code of conduct](https://github.com/fastruby/dotenv_validator/blob/main/CODE_OF_CONDUCT.md).
