### PR TITLE
[bugfix]: runs-on field in lint workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Closes #52. 

Description:
Changed `runs-on` from the matrix variable to `ubuntu-latest`.

I believe this PR itself will serve as the test? 

**Update**: test passed.

I will abide by the [code of conduct](https://github.com/fastruby/dotenv_validator/blob/main/CODE_OF_CONDUCT.md).
