### PR TITLE
Add UUID validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/fastruby/dotenv_validator/compare/v1.1.0...main)
 
+* [FEATURE: Add UUID format](https://github.com/fastruby/dotenv_validator/pull/54)
 * [FEATURE: Better error management for a scenario where .env.sample is missing](https://github.com/fastruby/dotenv_validator/pull/40)
 * [FEATURE: Add boolean format](https://github.com/fastruby/dotenv_validator/pull/38)
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ THIS_IS_A_REQUIRED_EMAIL=123 #required,format=email
 - `email` (checks value against `/[\w@]+@[\w@]+\.[\w@]+/`)
 - `url` (checks value against `/https?:\/\/.+/`)
 - `bool` or `boolean` (checks value against `true` or `false`, case sensitive)
+- `uuid` (checks value against `/\A[\da-f]{32}\z/i` or `/\A[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}\z/i`)
 - any other value acts as a regexp!
 
 ### Regexp format

--- a/lib/dotenv_validator.rb
+++ b/lib/dotenv_validator.rb
@@ -37,6 +37,7 @@ module DotenvValidator
         when "email" then email?(value)
         when "url" then url?(value)
         when "bool", "boolean" then boolean?(value)
+        when "uuid" then uuid?(value)
         else
           value.match?(Regexp.new(Regexp.last_match(1)))
         end
@@ -120,6 +121,15 @@ module DotenvValidator
   # @return [Boolean] True if it is a boolean value. False otherwise.
   def self.boolean?(string)
     string.match?(/(true|false)/)
+  end
+
+  # It checks the value to check if it is a uuid or not.
+  #
+  # @param [String] A string
+  # @return [Boolean] True if it is a UUID value. False otherwise.
+  def self.uuid?(string)
+    string.match?(/\A[\da-f]{32}\z/i) ||
+      string.match?(/\A[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}\z/i)
   end
 
   def self.open_sample_file

--- a/spec/dot_env_validator_spec.rb
+++ b/spec/dot_env_validator_spec.rb
@@ -187,6 +187,106 @@ RSpec.describe DotenvValidator do
           end
         end
       end
+
+      context "and there is a uuid format parameter in the comment" do
+        let(:sample_lines) { StringIO.new("KEY_ID=9c382b2a-c84f-4dfd-8bc6-89dc413850bb # format=uuid") }
+
+        context "and ENV variable is a uuid in the default format" do
+          it "returns true" do
+            ClimateControl.modify KEY_ID: "ade67c20-bf67-4b10-ae9a-5809d9e1d041" do
+              expect(DotenvValidator.check).to be_truthy
+            end
+          end
+        end
+
+        context "and the ENV variable is a uuid in the compact format" do
+          it "returns true" do
+            ClimateControl.modify KEY_ID: "ade67c20bf674b10ae9a5809d9e1d041" do
+              expect(DotenvValidator.check).to be_truthy
+            end
+          end
+        end
+
+        context "and the ENV variable has invalid characters" do
+          around do |example|
+            ClimateControl.modify KEY_ID: "xde67c20bf674b10ae9a5809d9e1d041" do
+              example.run
+            end
+          end
+
+          it "returns false" do
+            expect(DotenvValidator.check).to be_falsey
+          end
+
+          it "displays a warning message in STDOUT" do
+            msg = "WARNING - Environment variables with invalid format: KEY_ID\n"
+
+            expect do
+              DotenvValidator.check
+            end.to output(msg).to_stdout
+          end
+        end
+
+        context "and the ENV variable is in an invalid format" do
+          around do |example|
+            ClimateControl.modify KEY_ID: "ade67c20bf674b10a-e9a5809d9e1d041" do
+              example.run
+            end
+          end
+
+          it "returns false" do
+            expect(DotenvValidator.check).to be_falsey
+          end
+
+          it "displays a warning message in STDOUT" do
+            msg = "WARNING - Environment variables with invalid format: KEY_ID\n"
+
+            expect do
+              DotenvValidator.check
+            end.to output(msg).to_stdout
+          end
+        end
+
+        context "and the ENV variable is too short" do
+          around do |example|
+            ClimateControl.modify KEY_ID: "ade67c20bf674b10a809d9e1d041" do
+              example.run
+            end
+          end
+
+          it "returns false" do
+            expect(DotenvValidator.check).to be_falsey
+          end
+
+          it "displays a warning message in STDOUT" do
+            msg = "WARNING - Environment variables with invalid format: KEY_ID\n"
+
+            expect do
+              DotenvValidator.check
+            end.to output(msg).to_stdout
+          end
+        end
+
+        context "and the ENV variable is too long" do
+          around do |example|
+            ClimateControl.modify KEY_ID: "ade67c20bf674b10ae9a5809d9e1d041a89b3d4a567" do
+              example.run
+            end
+          end
+
+          it "returns false" do
+            expect(DotenvValidator.check).to be_falsey
+          end
+
+          it "displays a warning message in STDOUT" do
+            msg = "WARNING - Environment variables with invalid format: KEY_ID\n"
+
+            expect do
+              DotenvValidator.check
+            end.to output(msg).to_stdout
+          end
+        end
+      end
     end
   end
 
@@ -283,6 +383,78 @@ RSpec.describe DotenvValidator do
             msg = "Environment variables with invalid format: MAYBE"
 
             ClimateControl.modify MAYBE: "possibly" do
+              expect do
+                DotenvValidator.check!
+              end.to raise_error(RuntimeError, msg)
+            end
+          end
+        end
+      end
+
+      context "and there is a uuid format parameter in the comment" do
+        let(:sample_lines) { StringIO.new("KEY_ID=9c382b2a-c84f-4dfd-8bc6-89dc413850bb # format=uuid") }
+
+        context "and ENV variable is a uuid in the default format" do
+          it "does not raise a runtime error" do
+            ClimateControl.modify KEY_ID: "ade67c20-bf67-4b10-ae9a-5809d9e1d041" do
+              expect do
+                DotenvValidator.check!
+              end.not_to raise_error
+            end
+          end
+        end
+
+        context "and the ENV variable is a uuid in the compact format" do
+          it "does not raise a runtime error" do
+            ClimateControl.modify KEY_ID: "ade67c20bf674b10ae9a5809d9e1d041" do
+              expect do
+                DotenvValidator.check!
+              end.not_to raise_error
+            end
+          end
+        end
+
+        context "and the ENV variable has invalid characters" do
+          it "raises a runtime error with a warning message" do
+            msg = "Environment variables with invalid format: KEY_ID"
+
+            ClimateControl.modify KEY_ID: "xde67c20bf674b10ae9a5809d9e1d041" do
+              expect do
+                DotenvValidator.check!
+              end.to raise_error(RuntimeError, msg)
+            end
+          end
+        end
+
+        context "and the ENV variable is in an invalid format" do
+          it "raises a runtime error with a warning message" do
+            msg = "Environment variables with invalid format: KEY_ID"
+
+            ClimateControl.modify KEY_ID: "ade67c20bf674b10ae-9a5809d9e1d041" do
+              expect do
+                DotenvValidator.check!
+              end.to raise_error(RuntimeError, msg)
+            end
+          end
+        end
+
+        context "and the ENV variable is too short" do
+          it "raises a runtime error with a warning message" do
+            msg = "Environment variables with invalid format: KEY_ID"
+
+            ClimateControl.modify KEY_ID: "ade67c20bf674b10809d9e1d041" do
+              expect do
+                DotenvValidator.check!
+              end.to raise_error(RuntimeError, msg)
+            end
+          end
+        end
+
+        context "and the ENV variable is too long" do
+          it "raises a runtime error with a warning message" do
+            msg = "Environment variables with invalid format: KEY_ID"
+
+            ClimateControl.modify KEY_ID: "ade67c20bf674b10ae9a5809d9e1d041a89b3d4a567" do
               expect do
                 DotenvValidator.check!
               end.to raise_error(RuntimeError, msg)


### PR DESCRIPTION
Description:

This closes #44 by adding the format validator for uuid

I'd like some comments on the specs I wrote. Not sure if I've tested unnecessary cases but since the idea is to validate correct format for the string, I thought it best to try as many invalid formats I could come up with

I will abide by the [code of conduct](https://github.com/fastruby/dotenv_validator/blob/main/CODE_OF_CONDUCT.md).
