### PR TITLE
[CHORE]: Update PR template to remind about CHANGELOG entry

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,6 @@
-**IMPORTANT: Please read the README before submitting pull requests for this project. Additionally, if your PR closes any open GitHub issues, make sure you include `Closes #XXXX`
+**IMPORTANT**: Please read the README before submitting pull requests for this project. Additionally, if your PR closes any open GitHub issues, make sure you include `Closes #XXXX`
+
+- [ ] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.
 
 Description:
 Please include a summary of the change and which issue is fixed or which feature is introduced.


### PR DESCRIPTION
**IMPORTANT: Please read the README before submitting pull requests for this project. Additionally, if your PR closes any open GitHub issues, make sure you include `Closes #XXXX`

Description:
This PR adds a checkbox reminding the contributor to create a CHANGELOG entry.

I will abide by the [code of conduct](https://github.com/fastruby/dotenv_validator/blob/main/CODE_OF_CONDUCT.md).
