### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main [(unreleased)](https://github.com/fastruby/dotenv_validator/compare/v1.1.0...main)
 
+# v1.2.0 /2022-04-04 [(commits)](https://github.com/fastruby/dotenv_validator/compare/v1.1.0...v1.2.0)
+
 * [FEATURE: Add UUID format](https://github.com/fastruby/dotenv_validator/pull/54)
 * [FEATURE: Better error management for a scenario where .env.sample is missing](https://github.com/fastruby/dotenv_validator/pull/40)
 * [FEATURE: Add boolean format](https://github.com/fastruby/dotenv_validator/pull/38)

--- a/lib/dotenv_validator/version.rb
+++ b/lib/dotenv_validator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DotenvValidator
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ if ENV["COVERAGE"] == "true"
 
   SimpleCov.start do
     track_files "lib/**/*.rb"
+    add_filter "lib/dotenv_validator/version.rb"
   end
 
   puts "Using SimpleCov v#{SimpleCov::VERSION}"


### PR DESCRIPTION
- [x] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.

This PR has all the changes needed to release a new version of this gem. It fixes #58 

I will abide by the [code of conduct](https://github.com/fastruby/dotenv_validator/blob/main/CODE_OF_CONDUCT.md).
