### PR TITLE
Test library with Ruby 3.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby: [2.5, 2.6, 2.7, 3.0]
+        ruby: [2.5, 2.6, 2.7, 3.0, 3.1]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Ruby 3.1 has been out for a while and we want to make sure changes and patches work with that version of Ruby too.

I will abide by the [code of conduct](https://github.com/fastruby/dotenv_validator/blob/main/CODE_OF_CONDUCT.md).
