### PR TITLE
Support .env.template if no .env.sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main [(unreleased)](https://github.com/fastruby/dotenv_validator/compare/v1.3.0...main)
 
+* [FEATURE: Support defining validations in the .env.template file](https://github.com/fastruby/dotenv_validator/pull/65)
+
 # v1.3.0 /2023-01-03 [(commits)](https://github.com/fastruby/dotenv_validator/compare/v1.2.0...v1.3.0)
 
 * [FEATURE: Add ruby types support](https://github.com/fastruby/dotenv_validator/pull/61)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Gem Version](https://badge.fury.io/rb/dotenv_validator.svg)](https://badge.fury.io/rb/dotenv_validator) [![Matrix Testing + Lint](https://github.com/fastruby/dotenv_validator/actions/workflows/main.yml/badge.svg)](https://github.com/fastruby/dotenv_validator/actions/workflows/main.yml) [![codecov](https://codecov.io/gh/fastruby/dotenv_validator/branch/main/graph/badge.svg)](https://codecov.io/gh/fastruby/dotenv_validator) [![Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/gems/dotenv_validator/) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
 This gem validates `.env` variables. You can configure validation rules by
-adding the appropriate comments to the `.env.sample` file.
+adding the appropriate comments to the `.env.sample` or `.env.template` file.
 
 # Installation
 
@@ -33,7 +33,7 @@ bundle update dotenv_validator
 
 # Configuring env variable
 
-In your `.env.sample` file, you can add comments to tell DotenvValidator how to validate the variable:
+In your `.env.sample` or `.env.template` file, you can add comments to tell DotenvValidator how to validate the variable:
 
 ```
 MY_REQUIRED_VAR=value #required
@@ -73,15 +73,19 @@ For more information check this [page](https://docs.docker.com/compose/environme
 The workaround is to rename your `.env` file when using docker. [Here](https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use) you'll find all naming options acceptable for dotenv and that Docker will not automatically parse.
 
 If renaming is not an option, then you need to remove any comments or trailing whitespaces from your `.env` file:
+
 ```
 SMTP_PORT=25         #format=int
 ```
+
 needs to become:
+
 ```
 SMTP_PORT=25
 ```
 
 ### TL;DR
+
 Rename your `.env` file according to this [table](https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use)
 
 or
@@ -96,13 +100,13 @@ Bug reports and pull requests are welcome on GitHub at [https://github.com/fastr
 
 When Submitting a Pull Request:
 
-* If your PR closes any open GitHub issues, please include `Closes #XXXX` in your comment
+- If your PR closes any open GitHub issues, please include `Closes #XXXX` in your comment
 
-* Please include a summary of the change and which issue is fixed or which feature is introduced.
+- Please include a summary of the change and which issue is fixed or which feature is introduced.
 
-* If changes to the behavior are made, clearly describe what changes.
+- If changes to the behavior are made, clearly describe what changes.
 
-* If changes to the UI are made, please include screenshots of the before and after.
+- If changes to the UI are made, please include screenshots of the before and after.
 
 ## Sponsorship
 

--- a/dotenv_validator.gemspec
+++ b/dotenv_validator.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
     "luis@ombulabs.com",
     "robert@ombulabs.com"]
   s.licenses = ["MIT"]
-  s.summary = "Checks required env variables and its format using .env.sample"
-  s.description = "Checks required env variables and its format using dotenv and .env.sample files. Sample files include validation documentation which is interpreted and used to validate your environment."
+  s.summary = "Checks required env variables and its format using .env.sample or .env.template"
+  s.description = "Checks required env variables and its format using dotenv and .env.sample/.env.template files. Sample/Template files include validation documentation which is interpreted and used to validate your environment."
   s.homepage = "https://github.com/fastruby/dotenv_validator"
   s.files = [
     "lib/dotenv_validator/version.rb",

--- a/lib/dotenv_validator.rb
+++ b/lib/dotenv_validator.rb
@@ -136,14 +136,12 @@ module DotenvValidator
   end
 
   def self.open_reference_file
+    sample_file
+  rescue Errno::ENOENT
     begin
-      sample_file
+      template_file
     rescue Errno::ENOENT
-      begin
-        template_file
-      rescue Errno::ENOENT
-        raise DotenvValidator::SampleFileNotFoundError, "Neither .env.sample nor .env.template files found!"
-      end
+      raise DotenvValidator::SampleFileNotFoundError, "Neither .env.sample nor .env.template files found!"
     end
   end
 

--- a/lib/dotenv_validator.rb
+++ b/lib/dotenv_validator.rb
@@ -4,7 +4,7 @@ require "fast_blank"
 require "pathname"
 require "dotenv_validator/errors"
 
-# Knows how to check the environment variables against the commends defined
+# Knows how to check the environment variables against the comments defined
 # in every line of your .env.sample or .env.template file.
 module DotenvValidator
   # It analyzes the current environment and it compares it to the documentation

--- a/spec/dot_env_validator_spec.rb
+++ b/spec/dot_env_validator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DotenvValidator do
   before do
     allow($stdout).to receive(:puts) # this supresses puts
   end
-  
+
   around do |example|
     ClimateControl.modify RAILS_ROOT: "./spec/support" do
       example.run

--- a/spec/support/.env.template
+++ b/spec/support/.env.template
@@ -1,0 +1,1 @@
+RAILS_APP=false # required


### PR DESCRIPTION
- [x] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.

Description:

This PRs adds a fallback to also support `.env.template` if `.env.sample` is not present. The `.env.template` file is created by dotenv itself when using the `dotenv -t .env` command, so it's important to support it since many users of dotenv could be using that instead of `.env.sample`. https://github.com/bkeepers/dotenv/tree/master#should-i-commit-my-env-file

This fixes https://github.com/fastruby/dotenv_validator/issues/63

I had to refactor the tests a big to be able to test this better.

I will abide by the [code of conduct](https://github.com/fastruby/dotenv_validator/blob/main/CODE_OF_CONDUCT.md).
